### PR TITLE
Fix scopes.json example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Example :
 
 .. code-block:: json
 
-    ['https://mail.google.com/', ..., ...]
+    ["https://mail.google.com/"]
 
 
 Usage


### PR DESCRIPTION
Make the scopes.json example in README a valid one by using using double
quotes and removing ellipsis.