### PR TITLE
Make the README easier to follow along

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,16 +11,34 @@ Configuration
 You need to create :code:`config.json` and :code:`scopes.json` at
 :code:`$XDG_CONFIG_HOME/oauth2token/<provider>/` for each provider you want
 to use.
-:code:`config.json` :
 
-See Google client_secret.json_.
+:code:`config.json`
+~~~~~~~~~~~~~~~~~~~~
+
+The main configuration file.
+Follow the format on client_secret.json_, using your own information obtained
+from your provider.
 
 .. _client_secret.json: https://github.com/googleapis/google-api-python-client/blob/master/docs/client-secrets.md
 
-You'll need to obtain your own from the provider.
+Example (Just change the :code:`client_id` and :code:`client_secret` values to
+the ones you got from Google):
 
-:code:`scopes.json`:
-The scope your application need as a json array.
+.. code-block:: json
+
+    {
+        "web": {
+            "client_id": "asdfjasdljfasdkjf",
+            "client_secret": "1912308409123890",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://accounts.google.com/o/oauth2/token"
+        }
+    }
+
+:code:`scopes.json`
+~~~~~~~~~~~~~~~~~~~~
+
+The scope your application needs. It's a json array containing the URLs.
 
 Example :
 
@@ -35,12 +53,10 @@ Usage
 
 :code:`oauth2create` <provider> <account>
 
-Obtain and store credentials in
-`$XDG_DATA_HOME/oauth2token/<provider>/<account>` in binary
-form, using the configuration for that provider. It use the "Installed App flow"
-open a brower where you'll need to log in the account you want to use, then
-redirect to the loopback address to obtain the credentials.
-
+Obtain and store credentials for the account in
+:code:`$XDG_DATA_HOME/oauth2token/<provider>/<account>`, using the configuration
+for that provider. It opens a browser where you'll need to log in the account
+you want to use.
 
 :code:`oauth2get` <provider> <account>
 


### PR DESCRIPTION
Make the `config.json` and `scopes.json` sections clearer, show a straightforward example for `config.json` and simplify the explanation for `oauth2create`.
All this should make it easier to follow along the README when setting up.