### PR TITLE
Accept an optional port flag for the callback server

### DIFF
--- a/bin/oauth2create
+++ b/bin/oauth2create
@@ -7,5 +7,6 @@ from oauth2token.token_mgmt import create_user_credentials
 parser = argparse.ArgumentParser()
 parser.add_argument('app')
 parser.add_argument('user', default=os.getenv('USER'))
+parser.add_argument('-p', '--port', default=0, help="Port to listen on")
 args = parser.parse_args()
-create_user_credentials(user=args.user, app=args.app)
+create_user_credentials(user=args.user, app=args.app, port=int(args.port))

--- a/oauth2token/token_mgmt.py
+++ b/oauth2token/token_mgmt.py
@@ -8,12 +8,12 @@ from google.auth.transport.requests import Request
 from .app_creds import get_json_config, get_credentials_file
 
 
-def create_user_credentials(app=None, user=None, **kwargs): 
+def create_user_credentials(app=None, user=None, port=0, **kwargs):
     flow = InstalledAppFlow.from_client_config(
             *get_json_config(app=app)
        )
 
-    flow.run_local_server(port=0)
+    flow.run_local_server(port=port)
 
     creds = flow.credentials
     creds._scopes = flow.oauth2session.token["scope"]


### PR DESCRIPTION
Since the port has to be part of allowlisted URLs preregistered with some providers, add the ability to pass in one of the allowed ports into oauth2create.